### PR TITLE
[AUTH-245] Make processor plugins configurable

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -232,3 +232,36 @@ syslog_best_effort: "false"
 # For each combination a field is created.
 # Its name is created concatenating identifier, sdparam_separator, and parameter name.
 syslog_sdparam_separator: "_"
+
+##
+# Regex processor plugin configuration.
+#
+# https://github.com/influxdata/telegraf/tree/master/plugins/processors/regex
+##
+
+# regex_namepass: []
+# regex_order: 1
+regex_fields: []
+regex_tags: []
+
+##
+# Regex processor plugin configuration.
+#
+# https://github.com/influxdata/telegraf/tree/master/plugins/processors/converter
+##
+
+# converter_namepass: []
+# converter_order: 1
+converter_tag_to_measurement: []
+converter_tag_to_string: []
+converter_tag_to_integer: []
+converter_tag_to_unsigned: []
+converter_tag_to_boolean: []
+converter_tag_to_float: []
+converter_field_to_tag: []
+converter_field_to_measurement: []
+converter_field_to_string: []
+converter_field_to_integer: []
+converter_field_to_unsigned: []
+converter_field_to_boolean: []
+converter_field_to_float: []

--- a/templates/plugins/processors.converter.conf.j2
+++ b/templates/plugins/processors.converter.conf.j2
@@ -1,12 +1,24 @@
-# Convert values to another metric value type
 [[processors.converter]]
-  namepass = ["syslog"]
-  order = 2
+{% if converter_namepass is defined and converter_namepass|length > 0 %}
+  namepass = {{ converter_namepass | to_json }}
+{% endif %}
+{% if converter_order is defined %}
+  order = {{ converter_order }}
+{% endif %}
 
-  ## Fields to convert
-  ##
-  ## The table key determines the target type, and the array of key-values
-  ## select the keys to convert.  The array may contain globs.
-  ##   <target-type> = [<field-key>...]
+  [processors.converter.tags]
+    measurement = {{ converter_tag_to_measurement | to_json }}
+    string = {{ converter_tag_to_string | to_json }}
+    integer = {{ converter_tag_to_integer | to_json }}
+    unsigned = {{ converter_tag_to_unsigned | to_json }}
+    boolean = {{ converter_tag_to_boolean | to_json }}
+    float = {{ converter_tag_to_float | to_json }}
+
   [processors.converter.fields]
-    tag = ["type", "base_url"]
+    measurement = {{ converter_field_to_measurement | to_json }}
+    tag = {{ converter_field_to_tag | to_json}}
+    string = {{ converter_field_to_string | to_json}}
+    integer = {{ converter_field_to_integer | to_json}}
+    unsigned = {{ converter_field_to_unsigned | to_json}}
+    boolean = {{ converter_field_to_boolean | to_json}}
+    float = {{ converter_field_to_float | to_json}}

--- a/templates/plugins/processors.regex.conf.j2
+++ b/templates/plugins/processors.regex.conf.j2
@@ -1,57 +1,30 @@
 [[processors.regex]]
-  namepass = ["syslog"]
-  order = 1
+{% if regex_namepass is defined and regex_namepass|length > 0 %}
+  namepass = {{ regex_namepass | to_json }}
+{% endif %}
+{% if regex_order is defined %}
+  order = {{ regex_order }}
+{% endif %}
 
+{% for field in regex_fields %}
   [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${base_url}"
-    result_key = "base_url"
+    key = "{{ field.key }}"
+    pattern = "{{ field.pattern }}"
+    replacement = "{{ field.replacement }}"
+{% if 'result_key' in field %}
+    result_key = "{{ field.result_key }}"
+{% endif %}
 
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${timestamp}"
-    result_key = "timestamp_part"
+{% else %}
+{% endfor %}
 
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${type}"
-    result_key = "type"
+{% for tag in regex_tags %}
+  [[processors.regex.tags]]
+    key = "{{ tag.key }}"
+    pattern = "{{ tag.pattern }}"
+    replacement = "{{ tag.replacement }}"
+{% if 'result_key' in tag %}
+    result_key = "{{ tag.result_key }}"
+{% endif %}
 
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${ip}"
-    result_key = "ip"
-
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${request_uri}"
-    result_key = "request_uri"
-
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${referer}"
-    result_key = "referer"
-
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${uid}"
-    result_key = "uid"
-
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${link}"
-    result_key = "link"
-
-  [[processors.regex.fields]]
-    key = "message"
-    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)\\|(?P<type>.*)\\|(?P<ip>\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\|(?P<request_uri>.*)\\|(?P<referer>.*)\\|(?P<uid>\\d+)\\|(?P<link>.*?)\\|(?P<message>.*)"
-    replacement = "${message}"
-    result_key = "message_part"
+{% endfor %}


### PR DESCRIPTION
### How to review:
- [ ] Add next lines into `config.yml` file:
  ```yaml
  converter_namepass: ["syslog"]
  converter_order: 2
  converter_field_to_tag: ["type", "base_url"]

  regex_namepass: ["syslog"]
  regex_order: 1
  regex_fields:
    - key: "message"
      pattern: ^(?P<base_url>.*)\\|(?P<timestamp>\\d+)
      replacement: "${base_url}"
      result_key: "base_url"
  
    - key: "message"
      pattern: ^(?P<base_url>.*)\\|(?P<timestamp>\\d+)
      replacement: "${timestamp}"
      result_key: "timestamp_part"
  ```
- [ ] Make sure that you get `processors.converter.conf` file like this
  ```toml
  [[processors.converter]]
  namepass = ["syslog"]
  order = 2

  [processors.converter.tags]
    measurement = []
    string = []
    integer = []
    unsigned = []
    boolean = []
    float = []

  [processors.converter.fields]
    measurement = []
    tag = ["type", "base_url"]
    string = []
    integer = []
    unsigned = []
    boolean = []
    float = []

  ```
- [ ] Make sure that you get `processors.regex.conf` file like this
  ```toml
  [[processors.regex]]
  namepass = ["syslog"]
  order = 1

  [[processors.regex.fields]]
    key = "message"
    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)"
    replacement = "${base_url}"
    result_key = "base_url"

  [[processors.regex.fields]]
    key = "message"
    pattern = "^(?P<base_url>.*)\\|(?P<timestamp>\\d+)"
    replacement = "${timestamp}"
    result_key = "timestamp_part"

  ```