### PR TITLE
Fix message reduction

### DIFF
--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -1,3 +1,4 @@
+$RepeatedMsgReduction off
 $ActionQueueType LinkedList
 $ActionQueueFileName srvrfwd
 $ActionResumeRetryCount -1


### PR DESCRIPTION
### The problem
Messages like `message repeated 9 times: ...` break Telegraf's regex for parsing base URL.

### Te solution

Rsyslogd has a parameter to remove shits reduction.
https://www.rsyslog.com/doc/master/configuration/action/rsconf1_repeatedmsgreduction.html