### PR TITLE
feat: add influxdb_v2 output plugin

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -93,12 +93,20 @@ input_plugins:
 processor_plugins: []
 
 output_plugins:
-  - influxdb
+  # - influxdb
+  - influxdb_v2
 
+# Configuration for InfluxDB v1
 influxdb_urls: []
 influxdb_database: "telegraf"
 influxdb_username: ""
 influxdb_password: ""
+
+# Configuration for InfluxD v2
+influxdb_v2_urls: []
+influxdb_v2_token: ""
+influxdb_v2_organization: ""
+influxdb_v2_bucket: ""
 
 ##
 # CPU input plugin configuration.

--- a/tasks/plugins/outputs.influxdb_v2.yml
+++ b/tasks/plugins/outputs.influxdb_v2.yml
@@ -1,0 +1,9 @@
+---
+
+- name: "Configure InfluxDB v2 output plugin"
+  template:
+    src: ../../templates/plugins/outputs.influxdb_v2.conf.j2
+    dest: /etc/telegraf/telegraf.d/outputs.influxdb_v2.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/templates/plugins/outputs.influxdb_v2
+++ b/templates/plugins/outputs.influxdb_v2
@@ -1,0 +1,7 @@
+# Configuration for sending metrics to InfluxDB 2.0
+# See https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb_v2
+[[outputs.influxdb_v2]]
+  urls = {{ influxdb_v2_urls | to_json }}
+  token = "{{ influxdb_v2_token }}"
+  organization = "{{ influxdb_v2_organization }}"
+  bucket = "{{ influxdb_v2_bucket }}"


### PR DESCRIPTION
Adding integration for InfluxDB v2 plugin.
See: https://github.com/influxdata/telegraf/tree/master/plugins/outputs/influxdb_v2
